### PR TITLE
Add expiration date support for API keys

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,8 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "orchestra/testbench": "^8.0"
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
     }
 }

--- a/database/migrations/2025_05_09_160000_alter_api_keys_table_add_expires_at.php
+++ b/database/migrations/2025_05_09_160000_alter_api_keys_table_add_expires_at.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('api_keys', 'expires_at')) {
+            Schema::table('api_keys', function (Blueprint $table) {
+                $table->timestamp('expires_at')->nullable()->after('last_used_at');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('api_keys', 'expires_at')) {
+            Schema::table('api_keys', function (Blueprint $table) {
+                $table->dropColumn('expires_at');
+            });
+        }
+    }
+};

--- a/database/migrations/2025_05_09_160000_alter_api_keys_table_add_expires_at.php
+++ b/database/migrations/2025_05_09_160000_alter_api_keys_table_add_expires_at.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class AlterApiKeysTableAddExpiresAt extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Console/Commands/GenerateApiKey.php
+++ b/src/Console/Commands/GenerateApiKey.php
@@ -15,7 +15,8 @@ class GenerateApiKey extends Command
     protected $signature = 'api-key:generate
                             {--id= : ID of the model you want to bind to this API key}
                             {--type= : The class name of the model you want to bind to this API key}
-                            {--name= : The name you want to give to this API key}';
+                            {--name= : The name you want to give to this API key}
+                            {--expires_at= : Expiration date of the API key in format YYYY-MM-DD or YYYY-MM-DD H:i (default: null}';
 
     /**
      * The console command description.
@@ -39,10 +40,26 @@ class GenerateApiKey extends Command
      */
     public function handle()
     {
+        $expiresAt = $this->option('expires_at') ?? null;
+
+        if ($expiresAt) {
+            try {
+                $dateTime = \DateTime::createFromFormat('Y-m-d H:i', $expiresAt) ?: \DateTime::createFromFormat('Y-m-d', $expiresAt);
+                if (!$dateTime) {
+                    throw new \Exception('Invalid date format');
+                }
+                $expiresAt = $dateTime->format('Y-m-d H:i:s');
+            } catch (\Exception $e) {
+                $this->error('Invalid expiration date format. Use YYYY-MM-DD or YYYY-MM-DD H:i.');
+                return;
+            }
+        }
+
         $apiKey = (new ApiKey)->create([
             'keyable_id' => $this->option('id'),
             'keyable_type' => $this->option('type'),
             'name' => $this->option('name'),
+            'expires_at' => $expiresAt,
         ]);
 
         $this->info('The following API key was created: ' . "{$apiKey->getKey()}|{$apiKey->plainTextApiKey}");

--- a/src/Keyable.php
+++ b/src/Keyable.php
@@ -17,7 +17,9 @@ trait Keyable
         $planTextApiKey = ApiKey::generate();
         if (isset($attributes['expires_at'])) {
             $dateTime = \DateTime::createFromFormat('Y-m-d H:i', $attributes['expires_at']) ?: \DateTime::createFromFormat('Y-m-d', $attributes['expires_at']);
-
+            if ($dateTime === false) {
+                throw new \InvalidArgumentException('Invalid date format. Expected format: Y-m-d H:i or Y-m-d');
+            }
             $attributes['expires_at'] = (
                 $dateTime
                     ? $dateTime->format('Y-m-d H:i:s')
@@ -29,10 +31,10 @@ trait Keyable
             return $this->apiKeys()->create([
                 'key' => hash('sha256', $planTextApiKey),
                 'name' => $attributes['name'] ?? null,
-                'expires_at' => $attributes['expires_at'],
+                'expires_at' => $attributes['expires_at'] ?? null,
             ]);
         });
 
-        return new NewApiKey($apiKey, "{$apiKey->getKey()}|{$planTextApiKey}|ExpiredAt:{$apiKey->expires_at}");
+        return new NewApiKey($apiKey, "{$apiKey->getKey()}|{$planTextApiKey}");
     }
 }

--- a/src/Keyable.php
+++ b/src/Keyable.php
@@ -15,14 +15,24 @@ trait Keyable
     public function createApiKey(array $attributes = []): NewApiKey
     {
         $planTextApiKey = ApiKey::generate();
+        if (isset($attributes['expires_at'])) {
+            $dateTime = \DateTime::createFromFormat('Y-m-d H:i', $attributes['expires_at']) ?: \DateTime::createFromFormat('Y-m-d', $attributes['expires_at']);
+
+            $attributes['expires_at'] = (
+                $dateTime
+                    ? $dateTime->format('Y-m-d H:i:s')
+                    : null
+            );
+        }
 
         $apiKey = Model::withoutEvents(function () use ($planTextApiKey, $attributes) {
             return $this->apiKeys()->create([
                 'key' => hash('sha256', $planTextApiKey),
                 'name' => $attributes['name'] ?? null,
+                'expires_at' => $attributes['expires_at'],
             ]);
         });
 
-        return new NewApiKey($apiKey, "{$apiKey->getKey()}|{$planTextApiKey}");
+        return new NewApiKey($apiKey, "{$apiKey->getKey()}|{$planTextApiKey}|ExpiredAt:{$apiKey->expires_at}");
     }
 }

--- a/src/Models/ApiKey.php
+++ b/src/Models/ApiKey.php
@@ -21,10 +21,12 @@ class ApiKey extends Model
         'keyable_type',
         'name',
         'last_used_at',
+        'expires_at',
     ];
 
     protected $casts = [
         'last_used_at' => 'datetime',
+        'expires_at' => 'datetime',
     ];
 
     public static function boot()
@@ -70,7 +72,9 @@ class ApiKey extends Model
      */
     public static function getByKey($key)
     {
-        return self::ofKey($key)->first();
+        return self::ofKey($key)
+            ->validKey()
+            ->first();
     }
 
     /**
@@ -132,5 +136,13 @@ class ApiKey extends Model
 
         return $query->where('id', $id)
             ->where('key', hash('sha256', $key));
+    }
+
+    public function scopeValidKey(Builder $query): Builder
+    {
+        return $query->where(function (Builder $query) {
+            $query->whereNull('expires_at')
+                  ->orWhere('expires_at', '>', now());
+        });
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -58,6 +58,8 @@ class TestCase extends OrchestraTestCase
     {
         include_once __DIR__ . '/../database/migrations/2019_04_09_225232_create_api_keys_table.php';
         (new \CreateApiKeysTable())->up();
+        include_once __DIR__ . '/../database/migrations/2025_05_09_160000_alter_api_keys_table_add_expires_at.php';
+        (new \AlterApiKeysTableAddExpiresAt())->up();
     }
 
     protected function prepareDatabaseForHasCustomFieldsModel()


### PR DESCRIPTION
- Introduced 'expires_at' column in the api_keys table migration.
- Updated GenerateApiKey command to accept an expiration date option.
- Enhanced createApiKey method to handle expiration date formatting.
- Added validKey scope to ApiKey model to filter out expired keys.